### PR TITLE
fix: 크고 작은 에러들 수정

### DIFF
--- a/src/main/java/lotto/util/ResultMessage.java
+++ b/src/main/java/lotto/util/ResultMessage.java
@@ -21,6 +21,7 @@ public class ResultMessage {
         this.bonusMatched = bonusMatched;
         this.resultMessage = new StringBuilder();
         bonusResultTurn = false;
+        System.out.println(drawResult);
         createMessage();
     }
 
@@ -31,13 +32,6 @@ public class ResultMessage {
 
     public void printResultMessage() {
         System.out.println(resultMessage);
-    }
-
-    private void createMessageBody() {
-        List<Integer> sortedResult = sortDrawResult();
-        for (int matchAmount : sortedResult) {
-            resultMessage.append(createMessageBodyLine(matchAmount));
-        }
     }
 
     private void createMessageHeader() {
@@ -57,35 +51,38 @@ public class ResultMessage {
         return format.format(prize);
     }
 
+    private void createMessageBody() {
+        List<Integer> sortedResult = sortDrawResult();
+        for (int matchAmount : sortedResult) {
+            resultMessage.append(createMessageBodyLine(matchAmount));
+        }
+    }
+
     private String createMessageBodyLine(int matchAmount) {
         StringBuilder messageBody = new StringBuilder();
         for (RankDetail rank : RankDetail.values()) {
             if (matchAmount == rank.getMatchAmount()) {
-                messageBody.append(makeLine(rank.getMatchAmount(), rank.getPrize()));
+                messageBody.append(createSingleMessageBodyLine(rank));
             }
         }
         return messageBody.toString();
     }
 
-
-    private String makeLine(int matchAmount, int prize) {
-        StringBuilder singleMessageBody = new StringBuilder();
-        if (matchAmount == 5) {
-            return makeLineWithBonus(matchAmount, prize);
+    private String createSingleMessageBodyLine(RankDetail rank) {
+        String prize = convertPrize(rank.getPrize());
+        if (rank.getRank().equals("bonus")) {
+            return String.format(MATCH_RESULT.getMessage(), rank.getMatchAmount(), BONUS_MATCHED.getMessage(),
+                    prize, bonusMatched) + "\n";
         }
-        singleMessageBody.append(
-                String.format(MATCH_RESULT.getMessage(), matchAmount, "", convertPrize(prize),
-                        drawResult.get(matchAmount))).append("\n");
-        return singleMessageBody.toString();
+        return String.format(MATCH_RESULT.getMessage(), rank.getMatchAmount(), "", prize,
+                drawResult.get(rank.getMatchAmount())) + "\n";
     }
 
-    private String makeLineWithBonus(int matchAmount, int prize) {
-        if (bonusResultTurn) {
-            return String.format(MATCH_RESULT.getMessage(), matchAmount, BONUS_MATCHED.getMessage(),
-                    convertPrize(prize), bonusMatched) + "\n";
-        }
-        bonusResultTurn = true;
-        return String.format(MATCH_RESULT.getMessage(), matchAmount, "", convertPrize(prize), bonusMatched) + "\n";
+
+
+    public void printYieldMessage(String yield) {
+        System.out.println(String.format(YIELD.getMessage(), yield));
     }
+
 
 }


### PR DESCRIPTION
## 💡 Motivation
- 추첨 결과의 계속된 오류 발생
    - 보너스상과 2등의 일치 숫자 갯수가 동일하게 5개 여서 오류 발생
- 요구사항대로 에러를 발생시키고 안내메세지를 출력 해야함


<br>

## 🔑 Key Changes
- `~~Validation` : 에러메세지를 생성해서 넘기고 최상단의 `Applicaiton` 에서 그 메세지를 출력하는 방식으로 변경
- `ResultMessage` : 등수들의 정보가 있는 `enum` 에 상수를 추가해서 해결
- `Lotto` : 테스트코드에서 `List.of()` 로 배열을 선언해서 넘기는데 이 경우 `immutable` 하기 때문에 정렬 불가능 
    - `stream` 을 사용해서 해결

<br>

## 🗒️ Todo
- 테스트 코드 작성


<br>
