### PR TITLE
fix: 수익률의 소숫점 표기 오류 수정

### DIFF
--- a/src/main/java/lotto/service/CalculateYield.java
+++ b/src/main/java/lotto/service/CalculateYield.java
@@ -19,7 +19,8 @@ public class CalculateYield {
     }
 
     public String getYield() {
-        double yield = ((((double) totalPrize / (double) userMoney) * 100) / 100.0) * 100;
+        double yield = ((double) totalPrize / (double) userMoney) * 100;
+        yield = Math.round((yield * 100) / 100.0);
         return String.valueOf(yield);
     }
 


### PR DESCRIPTION
## 💡 Motivation
- 소숫점 표기 오류


<br>

## 🔑 Key Changes
- `CalculateYield` : `Math.round()` 활용


<br>

## 🗒️ Todo
- 최종 점검


<br>
