### PR TITLE
fix: 수익률의 소숫점 표기 오류 수정

### DIFF
--- a/src/main/java/lotto/service/CalculateYield.java
+++ b/src/main/java/lotto/service/CalculateYield.java
@@ -20,7 +20,7 @@ public class CalculateYield {
 
     public String getYield() {
         double yield = ((double) totalPrize / (double) userMoney) * 100;
-        yield = Math.round((yield * 100) / 100.0);
+        yield = Math.round(yield * 100) / 100.0;
         return String.valueOf(yield);
     }
 


### PR DESCRIPTION
## 💡 Motivation
- 소숫점 첫번째 자리에서 반올림하는 오류 발생


<br>

## 🔑 Key Changes
- `CalculateYield`: `Math.round()` 를 실행하고 나눈는 방식으로 변경


<br>

## 🗒️ Todo
- 최종 점검


<br>
