### PR TITLE
fix: 수익률의 소숫점 표기 오류 수정

### DIFF
--- a/src/main/java/lotto/service/CalculateYield.java
+++ b/src/main/java/lotto/service/CalculateYield.java
@@ -2,6 +2,7 @@ package lotto.service;
 
 import lotto.view.RankDetail;
 
+import java.math.BigDecimal;
 import java.util.Map;
 
 public class CalculateYield {
@@ -21,7 +22,9 @@ public class CalculateYield {
     public String getYield() {
         double yield = ((double) totalPrize / (double) userMoney) * 100;
         yield = Math.round(yield * 100) / 100.0;
-        return String.valueOf(yield);
+        String convertedYield = String.format("%.1f", yield);
+        BigDecimal bigDecimal = BigDecimal.valueOf(Double.parseDouble(convertedYield)).setScale(1);
+        return String.valueOf(bigDecimal);
     }
 
     private void calculate() {


### PR DESCRIPTION
## 💡 Motivation
- 소숫점이 없을때 첫째자리가 표기되지 않는 오류 수정
- 숫자가 클때 `E` 가 표기되는 오류 수정

<br>

## 🔑 Key Changes
- `CalculateYield` : `Bigdecimal` 이용


<br>

## 🗒️ Todo
- 최종 점검


<br>
