### PR TITLE
fix: 수익률을 출력하는 부분 수정

### DIFF
--- a/src/main/java/lotto/util/ResultMessage.java
+++ b/src/main/java/lotto/util/ResultMessage.java
@@ -1,5 +1,6 @@
 package lotto.util;
 
+import lotto.service.CalculateYield;
 import lotto.view.RankDetail;
 
 import java.text.DecimalFormat;
@@ -11,15 +12,18 @@ import static lotto.view.RankMessageDetail.*;
 
 public class ResultMessage {
 
+    CalculateYield calculateYield;
     Map<Integer, Integer> drawResult;
     StringBuilder resultMessage;
+    int userMoney;
     int bonusMatched;
     boolean bonusResultTurn;
 
-    public ResultMessage(Map<Integer, Integer> drawResult, int bonusMatched) {
+    public ResultMessage(Map<Integer, Integer> drawResult, int bonusMatched, int userMoney) {
         this.drawResult = drawResult;
         this.bonusMatched = bonusMatched;
         this.resultMessage = new StringBuilder();
+        this.userMoney = userMoney;
         bonusResultTurn = false;
         createMessage();
     }
@@ -27,6 +31,7 @@ public class ResultMessage {
     private void createMessage() {
         createMessageHeader();
         createMessageBody();
+        createYieldMessage();
     }
 
     public void printResultMessage() {
@@ -90,8 +95,10 @@ public class ResultMessage {
     }
 
 
-    public void printYieldMessage(String yield) {
-        System.out.println(String.format(YIELD.getMessage(), yield));
+    public void createYieldMessage() {
+        calculateYield = new CalculateYield(drawResult, bonusMatched, userMoney);
+        String yield = calculateYield.getYield();
+        resultMessage.append(String.format(YIELD.getMessage(), yield));
     }
 
 


### PR DESCRIPTION
## 💡 Motivation
- 수익률을 출력하기 전에 공백이 출력되는 오류 발생


<br>

## 🔑 Key Changes
- `LottoService`:  수익률을 출력하는 부분을 삭제
- `ResultMessage`:  수익률을 출력하는 부분을 이동
- `LottoDraw` : 매직넘버를 `enum` 에서 가져온 값으로 변경

<br>

## 🗒️ Todo
- 최종점검


<br>
